### PR TITLE
Update Plugin to support 1.2.0b3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This experimental tool is a [Poetry Plugin](https://python-poetry.org/docs/maste
 
 ## Installation
 
-Make sure you are using at least Poetry 1.2.0a2. To install this preview release, run:
+Make sure you are using at least Poetry 1.2.0b3. To install this preview release, run:
 
 ```shell
 curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - --preview
@@ -13,14 +13,19 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-
 Install this plugin:
 
 ```shell
-poetry plugin add poetry-workspace-plugin
+poetry plugin add poetry-workspace-plugin2
 ```
+
+### Why plugin2?
+
+The [original package](https://pypi.org/project/poetry-workspace-plugin/) was released by [Martin Liu](https://pypi.org/user/martinxsliu/), a former OpenDoor employee. Before he left, he [re-released the project](https://pypi.org/project/poetry-workspace-plugin2/) under the [OpenDoor PyPI account](https://pypi.org/user/opendoor/).
 
 ## Workspace
 
 A workspace is a collection of Poetry projects that share a single environment.
 
 ## Example config to place at the root
+
 ```
 [tool.poetry]
 name = "code"

--- a/poetry_workspace/plugin.py
+++ b/poetry_workspace/plugin.py
@@ -2,7 +2,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from cleo.events.console_events import COMMAND
-from poetry.console.commands.installer_command import EnvCommand, InstallerCommand
+from poetry.console.commands.env_command import EnvCommand
+from poetry.console.commands.installer_command import InstallerCommand
 from poetry.core.factory import Factory as BaseFactory
 from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.core.version.pep440.version import PEP440Version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-workspace-plugin"
-version = "0.5.3"
+version = "0.5.5"
 description = "Multi project workspace plugin for Poetry"
 authors = ["Martin Liu <martin.xs.liu@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
The `poetry export` subcommand does not work under version 1.2.0a2 because the `ExportCommand` subclasses `Command`, which is not one of the command classes that this plugin monkey patches.

Fortunately, in a change in the 1.2.0x series, [it was changed to subclass `InstallerCommand`](https://github.com/python-poetry/poetry-plugin-export/blob/main/src/poetry_plugin_export/command.py#L15), which [we do monkey patch](https://github.com/opendoor-labs/poetry_workspace_plugin/blob/master/poetry_workspace/plugin.py#L43-L45) (the `set_installer_poetry` is the important bit). This should  allow `poetry export` to target the correct lockfile.

The only thing we require to be compatible is to import `EnvCommand` from `env_command.py`, which we are already doing elsewhere in this plugin, so it is a non-breaking change. 

As a followup to this PR, we will publish the new version to PyPI and upgrade `py/scripts/get_poetry.sh` in `opendoor-labs/code` to point to version 0.5.5.

https://opendoor.atlassian.net/browse/MLOPS-671